### PR TITLE
Add cycling static and dynamic analysis

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,9 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import ModeSelector from './components/ModeSelector';
+import CyclingModeSelector from './components/CyclingModeSelector';
 import CyclingCaptureView from './components/CyclingCaptureView';
+import CyclingStaticCaptureView from './components/CyclingStaticCaptureView';
 import StaticCaptureView from './components/StaticCaptureView';
 import RunningCaptureView from './components/RunningCaptureView';
 
@@ -21,13 +23,19 @@ const App: React.FC = () => {
         {/* Landing page - mode selection */}
         <Route path="/" element={<ModeSelector />} />
 
-        {/* Cycling analysis view - 4 test workflow */}
-        <Route path="/cycling" element={<CyclingCaptureView />} />
+        {/* Cycling mode selector - static vs dynamic */}
+        <Route path="/cycling" element={<CyclingModeSelector />} />
+
+        {/* Cycling dynamic analysis - 4 test workflow */}
+        <Route path="/cycling/dynamic" element={<CyclingCaptureView />} />
+
+        {/* Cycling static analysis - 2 step saddle height */}
+        <Route path="/cycling/static" element={<CyclingStaticCaptureView />} />
 
         {/* Running analysis view */}
         <Route path="/running" element={<RunningCaptureView />} />
 
-        {/* Static assessment view */}
+        {/* Static assessment view (postural) */}
         <Route path="/static" element={<StaticCaptureView />} />
 
         {/* Catch all - redirect to home */}

--- a/src/components/CyclingModeSelector.tsx
+++ b/src/components/CyclingModeSelector.tsx
@@ -1,0 +1,239 @@
+/**
+ * BiomechCoach - Cycling Mode Selector Component
+ *
+ * Allows users to choose between Static and Dynamic cycling analysis modes.
+ * - Static: Side view analysis at 6 o'clock position (heel on pedal vs clipped in)
+ * - Dynamic: Full 4-test workflow with multiple views during pedaling
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CyclingMode } from '../lib/poseTypes';
+
+/**
+ * Mode Card Component for cycling mode selection
+ */
+interface ModeCardProps {
+  mode: CyclingMode;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  features: string[];
+  onClick: () => void;
+  accentColor: 'blue' | 'green';
+}
+
+const ModeCard: React.FC<ModeCardProps> = ({
+  title,
+  description,
+  icon,
+  features,
+  onClick,
+  accentColor,
+}) => {
+  const colorClasses = {
+    blue: {
+      border: 'hover:border-blue-500',
+      bg: 'bg-blue-500/10 group-hover:bg-blue-500/20',
+      text: 'text-blue-400 group-hover:text-blue-300',
+      ring: 'focus:ring-blue-500',
+      bullet: 'bg-blue-500',
+    },
+    green: {
+      border: 'hover:border-green-500',
+      bg: 'bg-green-500/10 group-hover:bg-green-500/20',
+      text: 'text-green-400 group-hover:text-green-300',
+      ring: 'focus:ring-green-500',
+      bullet: 'bg-green-500',
+    },
+  };
+
+  const colors = colorClasses[accentColor];
+
+  return (
+    <button
+      onClick={onClick}
+      className={`group relative w-full max-w-md p-8 bg-gray-800 hover:bg-gray-750
+                 border border-gray-700 ${colors.border} rounded-2xl
+                 transition-all duration-300 transform hover:scale-[1.02]
+                 focus:outline-none focus:ring-2 ${colors.ring} focus:ring-offset-2
+                 focus:ring-offset-gray-900 text-left`}
+    >
+      {/* Icon */}
+      <div
+        className={`w-16 h-16 mb-6 rounded-xl ${colors.bg}
+                    flex items-center justify-center
+                    transition-colors duration-300`}
+      >
+        <div className={`${colors.text} transition-colors`}>{icon}</div>
+      </div>
+
+      {/* Title */}
+      <h3 className={`text-2xl font-bold text-white mb-2 ${colors.text} transition-colors`}>
+        {title}
+      </h3>
+
+      {/* Description */}
+      <p className="text-gray-400 text-sm leading-relaxed mb-4">{description}</p>
+
+      {/* Features list */}
+      <ul className="space-y-2">
+        {features.map((feature, index) => (
+          <li key={index} className="flex items-start gap-2 text-sm text-gray-500">
+            <span className={`w-1.5 h-1.5 ${colors.bullet} rounded-full mt-1.5 flex-shrink-0`} />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Arrow indicator */}
+      <div className={`mt-6 text-gray-500 ${colors.text} transition-colors`}>
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17 8l4 4m0 0l-4 4m4-4H3"
+          />
+        </svg>
+      </div>
+    </button>
+  );
+};
+
+/**
+ * Cycling Mode Selector Component
+ */
+const CyclingModeSelector: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleSelectMode = (mode: CyclingMode) => {
+    if (mode === 'static') {
+      navigate('/cycling/static');
+    } else {
+      navigate('/cycling/dynamic');
+    }
+  };
+
+  const handleBack = () => {
+    navigate('/');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-gradient-to-b from-gray-900 via-gray-900 to-gray-950">
+      {/* Back button */}
+      <button
+        onClick={handleBack}
+        className="absolute top-6 left-6 p-2 text-gray-400 hover:text-white hover:bg-gray-800 rounded-lg transition-colors"
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+
+      {/* Header */}
+      <div className="text-center mb-12">
+        {/* Icon */}
+        <div
+          className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-gradient-to-br from-biomech-500 to-biomech-700
+                      flex items-center justify-center shadow-lg shadow-biomech-500/20"
+        >
+          <svg className="w-12 h-12 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {/* Bicycle icon */}
+            <circle cx="5.5" cy="17.5" r="3.5" strokeWidth="1.5" />
+            <circle cx="18.5" cy="17.5" r="3.5" strokeWidth="1.5" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.5"
+              d="M5.5 17.5l4-9.5h4l2 5.5m0 0L18.5 17.5m-3-4l-4 4m0-8l2 4"
+            />
+            <circle cx="15" cy="6" r="1.5" fill="currentColor" />
+          </svg>
+        </div>
+
+        {/* Title */}
+        <h1 className="text-3xl md:text-4xl font-bold text-white mb-4">Analisi Ciclismo</h1>
+
+        {/* Subtitle */}
+        <p className="text-gray-400 text-lg max-w-lg mx-auto">
+          Scegli la modalita di analisi piu adatta alle tue esigenze
+        </p>
+      </div>
+
+      {/* Mode Selection Cards */}
+      <div className="flex flex-col md:flex-row gap-6 md:gap-8 w-full max-w-4xl justify-center">
+        <ModeCard
+          mode="static"
+          title="Analisi Statica"
+          description="Valuta l'altezza della sella con la gamba a ore 6. Ideale per una regolazione rapida e precisa."
+          onClick={() => handleSelectMode('static')}
+          accentColor="blue"
+          features={[
+            'Telecamera laterale',
+            'Due misurazioni: tallone e agganciato',
+            'Rilevamento automatico posizione',
+            'Analisi immediata degli angoli',
+          ]}
+          icon={
+            <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {/* Static/pause icon with measurement */}
+              <rect x="6" y="4" width="4" height="16" rx="1" strokeWidth="1.5" />
+              <rect x="14" y="4" width="4" height="16" rx="1" strokeWidth="1.5" />
+              <path strokeLinecap="round" strokeWidth="1.5" d="M2 12h2m16 0h2" />
+            </svg>
+          }
+        />
+
+        <ModeCard
+          mode="dynamic"
+          title="Analisi Dinamica"
+          description="Analisi completa durante la pedalata con 4 test da diverse angolazioni. Per una valutazione approfondita."
+          onClick={() => handleSelectMode('dynamic')}
+          accentColor="green"
+          features={[
+            '4 test: lato destro, sinistro, frontale, posteriore',
+            'Analisi in tempo reale durante la pedalata',
+            'Rilevamento cicli e angoli dinamici',
+            'Report dettagliato con raccomandazioni',
+          ]}
+          icon={
+            <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {/* Play/dynamic icon with motion */}
+              <polygon points="5,3 19,12 5,21" strokeWidth="1.5" strokeLinejoin="round" />
+              <path
+                strokeLinecap="round"
+                strokeWidth="1.5"
+                d="M22 12c0 2-1 4-2 5m0-10c1 1 2 3 2 5"
+              />
+            </svg>
+          }
+        />
+      </div>
+
+      {/* Info section */}
+      <div className="mt-12 text-center max-w-2xl">
+        <h4 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Quale scegliere?
+        </h4>
+        <div className="grid md:grid-cols-2 gap-4 text-sm text-gray-500">
+          <div className="p-4 bg-gray-800/50 rounded-lg">
+            <span className="text-blue-400 font-medium">Statica</span>: Per regolare rapidamente
+            l'altezza della sella. Bastano pochi minuti.
+          </div>
+          <div className="p-4 bg-gray-800/50 rounded-lg">
+            <span className="text-green-400 font-medium">Dinamica</span>: Per un'analisi completa
+            della posizione e della pedalata. Richiede ~15-20 minuti.
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <footer className="mt-12 text-center text-gray-600 text-xs">
+        <p>BiomechCoach - Analisi biomeccanica per ciclisti</p>
+      </footer>
+    </div>
+  );
+};
+
+export default CyclingModeSelector;

--- a/src/components/CyclingStaticCaptureView.tsx
+++ b/src/components/CyclingStaticCaptureView.tsx
@@ -1,0 +1,774 @@
+/**
+ * BiomechCoach - Cycling Static Capture View Component
+ *
+ * Static saddle height analysis with 2-step workflow:
+ * 1. Heel on pedal at 6 o'clock (full leg extension)
+ * 2. Clipped in at 6 o'clock (normal pedaling position)
+ *
+ * Features:
+ * - Side camera view
+ * - Auto-detection of ready position (knee angle > 120°)
+ * - Configurable countdown before measurement
+ * - Real-time angle display
+ * - Analysis and recommendations
+ */
+
+import React, { useEffect, useRef, useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CyclingStaticStep,
+  CyclingStaticStepConfig,
+} from '../lib/poseTypes';
+import useCameraStream from '../hooks/useCameraStream';
+import usePoseEstimation from '../hooks/usePoseEstimation';
+import useCyclingStaticAnalysis from '../hooks/useCyclingStaticAnalysis';
+import CameraFeed from './CameraFeed';
+import PoseOverlayCanvas from './PoseOverlayCanvas';
+
+/**
+ * Step configuration
+ */
+const STEP_CONFIG: Record<CyclingStaticStep, CyclingStaticStepConfig> = {
+  heel_on_pedal: {
+    step: 'heel_on_pedal',
+    label: 'Tallone sul Pedale',
+    instruction: 'Posiziona il TALLONE sul pedale a ore 6 (punto piu basso). La gamba dovrebbe essere quasi completamente estesa.',
+    icon: '1',
+  },
+  clipped_in: {
+    step: 'clipped_in',
+    label: 'Pedale Agganciato',
+    instruction: 'Ora aggancia il piede al pedale (o appoggia la palla del piede) a ore 6. Questa e la posizione normale di pedalata.',
+    icon: '2',
+  },
+};
+
+const STEP_ORDER: CyclingStaticStep[] = ['heel_on_pedal', 'clipped_in'];
+
+/**
+ * Format angle for display
+ */
+function formatAngle(angle: number | null | undefined): string {
+  if (angle === null || angle === undefined) return '--';
+  return `${Math.round(angle)}°`;
+}
+
+/**
+ * Get color class based on angle quality for saddle height
+ */
+function getKneeAngleColorClass(angle: number | null, step: CyclingStaticStep): string {
+  if (angle === null) return 'text-gray-400';
+
+  if (step === 'heel_on_pedal') {
+    // Heel on pedal should be ~170-180°
+    if (angle >= 170) return 'text-green-400';
+    if (angle >= 160) return 'text-yellow-400';
+    return 'text-red-400';
+  } else {
+    // Clipped in should be 145-155°
+    if (angle >= 145 && angle <= 155) return 'text-green-400';
+    if (angle >= 140 && angle <= 160) return 'text-yellow-400';
+    return 'text-red-400';
+  }
+}
+
+/**
+ * Cycling Static Capture View Component
+ */
+const CyclingStaticCaptureView: React.FC = () => {
+  const navigate = useNavigate();
+
+  // Camera hook
+  const {
+    videoRef,
+    status: cameraStatus,
+    error: cameraError,
+    startCamera,
+    stopCamera,
+    dimensions,
+    isStreaming,
+  } = useCameraStream();
+
+  // Pose estimation hook
+  const {
+    status: poseStatus,
+    error: poseError,
+    currentPose,
+    initialize: initializePose,
+    processFrame,
+  } = usePoseEstimation();
+
+  // Static analysis hook
+  const staticAnalysis = useCyclingStaticAnalysis();
+
+  // UI state
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [showResults, setShowResults] = useState(false);
+  const [customCountdown, setCustomCountdown] = useState(staticAnalysis.countdownDuration);
+
+  // Processing refs
+  const animationFrameRef = useRef<number>(0);
+  const lastProcessTimeRef = useRef<number>(0);
+
+  // Constants
+  const TARGET_FPS = 20;
+  const FRAME_INTERVAL = 1000 / TARGET_FPS;
+
+  // Current step
+  const currentStep = STEP_ORDER[currentStepIndex];
+  const currentStepConfig = STEP_CONFIG[currentStep];
+
+  /**
+   * Initialize pose model
+   */
+  useEffect(() => {
+    initializePose({ modelComplexity: 1 });
+  }, [initializePose]);
+
+  /**
+   * Main processing loop
+   */
+  const processLoop = useCallback(() => {
+    if (!isStreaming || poseStatus !== 'ready' || !videoRef.current) {
+      animationFrameRef.current = requestAnimationFrame(processLoop);
+      return;
+    }
+
+    const now = performance.now();
+    const elapsed = now - lastProcessTimeRef.current;
+
+    if (elapsed >= FRAME_INTERVAL) {
+      lastProcessTimeRef.current = now;
+
+      processFrame(videoRef.current).then((pose) => {
+        if (pose && pose.isValid) {
+          staticAnalysis.processFrame(pose);
+        }
+      });
+    }
+
+    animationFrameRef.current = requestAnimationFrame(processLoop);
+  }, [isStreaming, poseStatus, videoRef, processFrame, staticAnalysis, FRAME_INTERVAL]);
+
+  /**
+   * Start/stop processing loop
+   */
+  useEffect(() => {
+    if (isStreaming && poseStatus === 'ready') {
+      animationFrameRef.current = requestAnimationFrame(processLoop);
+    }
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [isStreaming, poseStatus, processLoop]);
+
+  /**
+   * Handle step completion
+   */
+  useEffect(() => {
+    if (staticAnalysis.status === 'completed') {
+      // Auto-advance to next step or show results
+      if (currentStepIndex < STEP_ORDER.length - 1) {
+        // Give user a moment to see the measurement was completed
+        const timer = setTimeout(() => {
+          setCurrentStepIndex(prev => prev + 1);
+          // Reset status for next measurement
+        }, 1500);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [staticAnalysis.status, currentStepIndex]);
+
+  /**
+   * Handle back navigation
+   */
+  const handleBack = () => {
+    stopCamera();
+    staticAnalysis.reset();
+    navigate('/cycling');
+  };
+
+  /**
+   * Handle start measurement
+   */
+  const handleStartMeasurement = () => {
+    staticAnalysis.setCountdownDuration(customCountdown);
+    staticAnalysis.startMeasurement(currentStep);
+  };
+
+  /**
+   * Handle view results
+   */
+  const handleViewResults = () => {
+    setShowResults(true);
+  };
+
+  /**
+   * Handle reset
+   */
+  const handleReset = () => {
+    staticAnalysis.reset();
+    setCurrentStepIndex(0);
+    setShowResults(false);
+  };
+
+  /**
+   * Get current angles for overlay
+   */
+  const getCurrentAnglesForOverlay = (): Record<string, number | null> => {
+    const angles = staticAnalysis.currentAngles;
+    return {
+      // Show knee angle prominently since that's what we're measuring
+      kneeAngle: angles.kneeAngle,
+      hipAngle: angles.hipAngle,
+    };
+  };
+
+  // If showing results, render results view
+  if (showResults && staticAnalysis.result) {
+    const { analysis } = staticAnalysis.result;
+    const { measurements } = staticAnalysis;
+
+    return (
+      <div className="min-h-screen bg-gray-900 flex flex-col">
+        {/* Header */}
+        <header className="bg-gray-800 border-b border-gray-700 px-4 py-3">
+          <div className="flex items-center justify-between max-w-4xl mx-auto">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => setShowResults(false)}
+                className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+              >
+                <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+              <h1 className="text-lg font-semibold text-white">Risultati Analisi Statica</h1>
+            </div>
+            <button
+              onClick={handleReset}
+              className="px-3 py-1.5 text-sm text-gray-300 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+            >
+              Nuovo Test
+            </button>
+          </div>
+        </header>
+
+        {/* Results content */}
+        <main className="flex-1 p-4 overflow-y-auto">
+          <div className="max-w-4xl mx-auto space-y-6">
+            {/* Score card */}
+            <div className="card p-6 text-center">
+              <div className={`text-6xl font-bold mb-2 ${
+                analysis.bikeFitScore >= 80 ? 'text-green-400' :
+                analysis.bikeFitScore >= 60 ? 'text-yellow-400' : 'text-red-400'
+              }`}>
+                {analysis.bikeFitScore}
+              </div>
+              <div className="text-gray-400">Punteggio Bike Fit</div>
+              <div className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gray-700">
+                <span className={`w-3 h-3 rounded-full ${
+                  analysis.saddleAssessment.status === 'optimal' ? 'bg-green-500' :
+                  analysis.saddleAssessment.status === 'unknown' ? 'bg-gray-500' : 'bg-yellow-500'
+                }`} />
+                <span className="text-white font-medium">
+                  {analysis.saddleAssessment.status === 'optimal' ? 'Sella OK' :
+                   analysis.saddleAssessment.status === 'too_low' ? 'Sella Troppo Bassa' :
+                   analysis.saddleAssessment.status === 'too_high' ? 'Sella Troppo Alta' : 'Da Valutare'}
+                </span>
+              </div>
+            </div>
+
+            {/* Measurements comparison */}
+            <div className="card p-6">
+              <h2 className="text-lg font-semibold text-white mb-4">Misurazioni</h2>
+              <div className="grid grid-cols-2 gap-4">
+                {/* Heel on pedal */}
+                <div className="bg-gray-700/50 rounded-lg p-4">
+                  <div className="text-sm text-gray-400 mb-1">Tallone sul Pedale</div>
+                  {measurements.heelOnPedal ? (
+                    <>
+                      <div className={`text-3xl font-bold ${getKneeAngleColorClass(measurements.heelOnPedal.kneeAngle, 'heel_on_pedal')}`}>
+                        {formatAngle(measurements.heelOnPedal.kneeAngle)}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-1">Ideale: 170°-180°</div>
+                    </>
+                  ) : (
+                    <div className="text-2xl text-gray-500">Non misurato</div>
+                  )}
+                </div>
+
+                {/* Clipped in */}
+                <div className="bg-gray-700/50 rounded-lg p-4">
+                  <div className="text-sm text-gray-400 mb-1">Pedale Agganciato</div>
+                  {measurements.clippedIn ? (
+                    <>
+                      <div className={`text-3xl font-bold ${getKneeAngleColorClass(measurements.clippedIn.kneeAngle, 'clipped_in')}`}>
+                        {formatAngle(measurements.clippedIn.kneeAngle)}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-1">Ideale: 145°-155°</div>
+                    </>
+                  ) : (
+                    <div className="text-2xl text-gray-500">Non misurato</div>
+                  )}
+                </div>
+              </div>
+
+              {/* Angle difference */}
+              {analysis.saddleAssessment.angleDifference !== null && (
+                <div className="mt-4 p-3 bg-gray-700/30 rounded-lg">
+                  <div className="text-sm text-gray-400">Differenza</div>
+                  <div className="text-xl font-bold text-white">
+                    {Math.round(analysis.saddleAssessment.angleDifference)}°
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Saddle assessment */}
+            <div className="card p-6">
+              <h2 className="text-lg font-semibold text-white mb-4">Valutazione Sella</h2>
+              <p className="text-gray-300 leading-relaxed">{analysis.saddleAssessment.assessment}</p>
+
+              {analysis.saddleAssessment.recommendations.length > 0 && (
+                <div className="mt-4 space-y-2">
+                  {analysis.saddleAssessment.recommendations.map((rec, idx) => (
+                    <div key={idx} className="flex items-start gap-2 text-sm">
+                      <span className="text-yellow-400 mt-0.5">!</span>
+                      <span className="text-gray-400">{rec}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Leg extension */}
+            <div className="card p-6">
+              <h2 className="text-lg font-semibold text-white mb-4">Estensione Gamba</h2>
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Con tallone:</span>
+                  <span className="text-white">{analysis.legExtensionAnalysis.heelExtension}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Con piede agganciato:</span>
+                  <span className="text-white">{analysis.legExtensionAnalysis.clippedExtension}</span>
+                </div>
+              </div>
+              {analysis.legExtensionAnalysis.assessment && (
+                <p className="mt-4 text-sm text-gray-400">{analysis.legExtensionAnalysis.assessment}</p>
+              )}
+            </div>
+
+            {/* Position assessment */}
+            {analysis.positionAssessment.assessment && (
+              <div className="card p-6">
+                <h2 className="text-lg font-semibold text-white mb-4">Posizione</h2>
+                <p className="text-gray-300">{analysis.positionAssessment.assessment}</p>
+                {(analysis.positionAssessment.hipAngle || analysis.positionAssessment.trunkAngle) && (
+                  <div className="mt-4 flex gap-4">
+                    {analysis.positionAssessment.hipAngle && (
+                      <div className="text-sm">
+                        <span className="text-gray-500">Anca: </span>
+                        <span className="text-white">{formatAngle(analysis.positionAssessment.hipAngle)}</span>
+                      </div>
+                    )}
+                    {analysis.positionAssessment.trunkAngle && (
+                      <div className="text-sm">
+                        <span className="text-gray-500">Tronco: </span>
+                        <span className="text-white">{formatAngle(analysis.positionAssessment.trunkAngle)}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Overall recommendations */}
+            {analysis.overallRecommendations.length > 0 && (
+              <div className="card p-6 bg-blue-900/20 border-blue-700">
+                <h2 className="text-lg font-semibold text-blue-400 mb-4">Raccomandazioni</h2>
+                <ul className="space-y-2">
+                  {analysis.overallRecommendations.map((rec, idx) => (
+                    <li key={idx} className="flex items-start gap-2">
+                      <span className="text-blue-400 mt-1">
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                        </svg>
+                      </span>
+                      <span className="text-gray-300">{rec}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Action buttons */}
+            <div className="flex gap-4">
+              <button
+                onClick={() => setShowResults(false)}
+                className="flex-1 py-3 px-6 text-gray-300 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+              >
+                Torna alla Misurazione
+              </button>
+              <button
+                onClick={handleBack}
+                className="flex-1 py-3 px-6 text-white bg-biomech-600 hover:bg-biomech-500 rounded-lg transition-colors"
+              >
+                Fine
+              </button>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 flex flex-col">
+      {/* Header */}
+      <header className="bg-gray-800 border-b border-gray-700 px-4 py-3">
+        <div className="flex items-center justify-between max-w-7xl mx-auto">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={handleBack}
+              className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+              title="Torna alla selezione"
+            >
+              <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <div>
+              <h1 className="text-lg font-semibold text-white">Analisi Statica Ciclismo</h1>
+              <p className="text-xs text-gray-400">
+                {poseStatus === 'ready' ? 'Modello pose pronto' : 'Caricamento modello...'}
+              </p>
+            </div>
+          </div>
+
+          {/* Step indicator */}
+          <div className="flex items-center gap-2">
+            {STEP_ORDER.map((step, index) => {
+              const completed = staticAnalysis.measurements[step === 'heel_on_pedal' ? 'heelOnPedal' : 'clippedIn'] !== null;
+              const isCurrent = index === currentStepIndex;
+
+              return (
+                <div
+                  key={step}
+                  className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm ${
+                    completed
+                      ? 'bg-green-600 text-white'
+                      : isCurrent
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-700 text-gray-400'
+                  }`}
+                >
+                  <span className="font-bold">{index + 1}</span>
+                  <span className="hidden sm:inline ml-1">{STEP_CONFIG[step].label}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* View results button */}
+          {staticAnalysis.result && (
+            <button
+              onClick={handleViewResults}
+              className="px-4 py-2 text-sm text-white bg-purple-600 hover:bg-purple-500 rounded-lg transition-colors"
+            >
+              Vedi Risultati
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 p-4">
+        <div className="max-w-7xl mx-auto">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            {/* Video feed with overlay */}
+            <div className="lg:col-span-2">
+              <div className="card overflow-hidden">
+                <CameraFeed
+                  ref={videoRef as React.RefObject<HTMLVideoElement>}
+                  status={cameraStatus}
+                  error={cameraError || poseError}
+                  onStart={startCamera}
+                  onStop={stopCamera}
+                  dimensions={dimensions}
+                  showFramingGuide={staticAnalysis.status !== 'measuring'}
+                  mode="cycling"
+                >
+                  {/* Pose overlay */}
+                  {dimensions && currentPose && (
+                    <PoseOverlayCanvas
+                      pose={currentPose}
+                      width={dimensions.width}
+                      height={dimensions.height}
+                      mirrored={false} // Side view, no mirroring
+                      showAngles={true}
+                      angles={getCurrentAnglesForOverlay()}
+                      mode="cycling"
+                    />
+                  )}
+
+                  {/* Countdown overlay */}
+                  {staticAnalysis.status === 'countdown' && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+                      <div className="text-center">
+                        <div className="text-8xl font-bold text-white animate-pulse">
+                          {staticAnalysis.countdownRemaining}
+                        </div>
+                        <div className="text-xl text-gray-300 mt-4">Mantieni la posizione...</div>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Measuring overlay */}
+                  {staticAnalysis.status === 'measuring' && (
+                    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                      <div className="bg-green-600/80 px-6 py-3 rounded-lg">
+                        <div className="text-xl font-bold text-white animate-pulse">
+                          Misurazione in corso...
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </CameraFeed>
+              </div>
+
+              {/* Controls */}
+              <div className="mt-4 p-4 bg-gray-800 rounded-lg">
+                {/* Step info */}
+                <div className="mb-4">
+                  <h2 className="text-xl font-bold text-white flex items-center gap-2">
+                    <span className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-lg">
+                      {currentStepConfig.icon}
+                    </span>
+                    {currentStepConfig.label}
+                  </h2>
+                  <p className="text-gray-400 mt-2">{currentStepConfig.instruction}</p>
+                </div>
+
+                {/* Ready position indicator */}
+                <div className={`mb-4 p-3 rounded-lg flex items-center gap-3 ${
+                  staticAnalysis.isInReadyPosition ? 'bg-green-600/20' : 'bg-gray-700'
+                }`}>
+                  <span className={`w-3 h-3 rounded-full ${
+                    staticAnalysis.isInReadyPosition ? 'bg-green-500 animate-pulse' : 'bg-gray-500'
+                  }`} />
+                  <span className={staticAnalysis.isInReadyPosition ? 'text-green-400' : 'text-gray-400'}>
+                    {staticAnalysis.isInReadyPosition
+                      ? 'Posizione rilevata! Pronto per la misurazione.'
+                      : 'Posiziona la gamba a ore 6 (pedale in basso)'}
+                  </span>
+                </div>
+
+                {/* Countdown selector */}
+                {staticAnalysis.status === 'idle' && (
+                  <div className="mb-4 flex items-center gap-3">
+                    <span className="text-gray-400 text-sm">Secondi di attesa:</span>
+                    <div className="flex gap-2">
+                      {[3, 5, 10].map(sec => (
+                        <button
+                          key={sec}
+                          onClick={() => setCustomCountdown(sec)}
+                          className={`px-3 py-1 rounded text-sm ${
+                            customCountdown === sec
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                          }`}
+                        >
+                          {sec}s
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Control buttons */}
+                <div className="flex gap-3">
+                  {staticAnalysis.status === 'idle' && (
+                    <button
+                      onClick={handleStartMeasurement}
+                      disabled={!isStreaming || poseStatus !== 'ready' || !staticAnalysis.isInReadyPosition}
+                      className="flex-1 py-3 px-6 text-lg font-semibold text-white bg-blue-600
+                               hover:bg-blue-500 disabled:bg-gray-600 disabled:cursor-not-allowed
+                               rounded-lg transition-colors"
+                    >
+                      {staticAnalysis.isInReadyPosition ? 'Avvia Misurazione' : 'Attendi Posizione...'}
+                    </button>
+                  )}
+
+                  {(staticAnalysis.status === 'countdown' || staticAnalysis.status === 'measuring') && (
+                    <button
+                      onClick={staticAnalysis.cancelMeasurement}
+                      className="flex-1 py-3 px-6 text-lg font-semibold text-white bg-red-600
+                               hover:bg-red-500 rounded-lg transition-colors"
+                    >
+                      Annulla
+                    </button>
+                  )}
+
+                  {staticAnalysis.status === 'completed' && currentStepIndex < STEP_ORDER.length - 1 && (
+                    <button
+                      onClick={() => setCurrentStepIndex(prev => prev + 1)}
+                      className="flex-1 py-3 px-6 text-lg font-semibold text-white bg-green-600
+                               hover:bg-green-500 rounded-lg transition-colors"
+                    >
+                      Prossimo Step
+                    </button>
+                  )}
+
+                  {staticAnalysis.status === 'completed' && currentStepIndex === STEP_ORDER.length - 1 && (
+                    <button
+                      onClick={handleViewResults}
+                      className="flex-1 py-3 px-6 text-lg font-semibold text-white bg-purple-600
+                               hover:bg-purple-500 rounded-lg transition-colors"
+                    >
+                      Vedi Risultati
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Side panel */}
+            <div className="space-y-4">
+              {/* Real-time angles */}
+              <div className="card p-4">
+                <h3 className="text-sm font-medium text-gray-300 mb-3">Angoli in Tempo Reale</h3>
+                <div className="space-y-3">
+                  <div>
+                    <div className="flex justify-between text-sm mb-1">
+                      <span className="text-gray-400">Ginocchio:</span>
+                      <span className={`font-mono font-bold ${
+                        getKneeAngleColorClass(staticAnalysis.currentAngles.kneeAngle, currentStep)
+                      }`}>
+                        {formatAngle(staticAnalysis.currentAngles.kneeAngle)}
+                      </span>
+                    </div>
+                    <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full transition-all ${
+                          staticAnalysis.currentAngles.kneeAngle
+                            ? staticAnalysis.currentAngles.kneeAngle >= 145
+                              ? 'bg-green-500'
+                              : 'bg-yellow-500'
+                            : 'bg-gray-600'
+                        }`}
+                        style={{
+                          width: `${Math.min(100, ((staticAnalysis.currentAngles.kneeAngle || 0) / 180) * 100)}%`
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-400">Anca:</span>
+                    <span className="text-white font-mono">
+                      {formatAngle(staticAnalysis.currentAngles.hipAngle)}
+                    </span>
+                  </div>
+
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-400">Tronco:</span>
+                    <span className="text-white font-mono">
+                      {formatAngle(staticAnalysis.currentAngles.trunkAngle)}
+                    </span>
+                  </div>
+
+                  <div className="flex justify-between text-sm border-t border-gray-700 pt-2">
+                    <span className="text-gray-400">Confidenza:</span>
+                    <span className={`font-mono ${
+                      staticAnalysis.currentAngles.confidence >= 0.8 ? 'text-green-400' :
+                      staticAnalysis.currentAngles.confidence >= 0.6 ? 'text-yellow-400' : 'text-red-400'
+                    }`}>
+                      {Math.round(staticAnalysis.currentAngles.confidence * 100)}%
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Measurements status */}
+              <div className="card p-4">
+                <h3 className="text-sm font-medium text-gray-300 mb-3">Misurazioni</h3>
+                <div className="space-y-3">
+                  {STEP_ORDER.map((step, index) => {
+                    const measurement = staticAnalysis.measurements[step === 'heel_on_pedal' ? 'heelOnPedal' : 'clippedIn'];
+                    const isCurrent = index === currentStepIndex;
+
+                    return (
+                      <div
+                        key={step}
+                        className={`p-3 rounded-lg ${
+                          measurement
+                            ? 'bg-green-600/20 border border-green-600/50'
+                            : isCurrent
+                            ? 'bg-blue-600/20 border border-blue-600/50'
+                            : 'bg-gray-700/50'
+                        }`}
+                      >
+                        <div className="flex items-center justify-between mb-1">
+                          <span className={`text-sm font-medium ${
+                            measurement ? 'text-green-400' : isCurrent ? 'text-blue-400' : 'text-gray-400'
+                          }`}>
+                            {STEP_CONFIG[step].label}
+                          </span>
+                          {measurement && (
+                            <svg className="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                            </svg>
+                          )}
+                        </div>
+                        {measurement ? (
+                          <div className="text-2xl font-bold text-white">
+                            {formatAngle(measurement.kneeAngle)}
+                          </div>
+                        ) : (
+                          <div className="text-sm text-gray-500">
+                            {isCurrent ? 'In attesa...' : 'Non ancora misurato'}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Reference info */}
+              <div className="card p-4">
+                <h3 className="text-sm font-medium text-gray-300 mb-2">Valori di Riferimento</h3>
+                <div className="text-xs text-gray-500 space-y-2">
+                  <div>
+                    <span className="text-gray-400">Tallone sul pedale:</span>
+                    <span className="text-white ml-2">170°-180° (gamba quasi dritta)</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-400">Pedale agganciato:</span>
+                    <span className="text-white ml-2">145°-155° (leggera flessione)</span>
+                  </div>
+                  <div className="pt-2 border-t border-gray-700">
+                    <span className="text-gray-400">Posizione:</span>
+                    <span className="text-white ml-2">Telecamera di lato, pedale a ore 6</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-gray-800 border-t border-gray-700 px-4 py-2 text-center text-xs text-gray-500">
+        BiomechCoach - Posiziona la telecamera di lato per una misurazione accurata
+      </footer>
+    </div>
+  );
+};
+
+export default CyclingStaticCaptureView;

--- a/src/hooks/useCyclingStaticAnalysis.ts
+++ b/src/hooks/useCyclingStaticAnalysis.ts
@@ -1,0 +1,592 @@
+/**
+ * BiomechCoach - Cycling Static Analysis Hook
+ *
+ * Real-time analysis for static cycling saddle height assessment.
+ * Measures knee angle at 6 o'clock position with:
+ * 1. Heel on pedal (should be ~180° = full extension)
+ * 2. Clipped in (should be 145-155°)
+ */
+
+import { useState, useCallback, useRef } from 'react';
+import {
+  PoseFrame,
+  CyclingStaticStep,
+  CyclingStaticMeasurement,
+  CyclingStaticResult,
+  CyclingStaticAnalysis,
+  CyclingStaticThresholds,
+  DEFAULT_CYCLING_STATIC_THRESHOLDS,
+} from '../lib/poseTypes';
+import {
+  angleBetweenPoints,
+  angleFromVertical,
+  keypointToPoint,
+  getKeypointByName,
+} from '../lib/vectorMath';
+
+/**
+ * Real-time angle values for static analysis
+ */
+export interface CyclingStaticAngles {
+  kneeAngle: number | null;
+  hipAngle: number | null;
+  ankleAngle: number | null;
+  trunkAngle: number | null;
+  confidence: number;
+}
+
+/**
+ * Status of the static analysis
+ */
+export type CyclingStaticStatus =
+  | 'idle'
+  | 'waiting_for_position'
+  | 'countdown'
+  | 'measuring'
+  | 'completed';
+
+/**
+ * Hook configuration
+ */
+export interface CyclingStaticConfig {
+  /** Countdown duration in seconds before measurement */
+  countdownSeconds: number;
+  /** Number of frames to average for measurement */
+  measurementFrames: number;
+  /** Thresholds for analysis */
+  thresholds: CyclingStaticThresholds;
+}
+
+const DEFAULT_CONFIG: CyclingStaticConfig = {
+  countdownSeconds: 5,
+  measurementFrames: 30, // ~1 second at 30fps
+  thresholds: DEFAULT_CYCLING_STATIC_THRESHOLDS,
+};
+
+/**
+ * Hook return type
+ */
+export interface UseCyclingStaticAnalysisReturn {
+  /** Process a new pose frame */
+  processFrame: (frame: PoseFrame) => void;
+  /** Current real-time angles */
+  currentAngles: CyclingStaticAngles;
+  /** Current analysis status */
+  status: CyclingStaticStatus;
+  /** Is the user in ready position (seated on bike, knee angle > threshold) */
+  isInReadyPosition: boolean;
+  /** Countdown seconds remaining */
+  countdownRemaining: number;
+  /** Start measurement for a step */
+  startMeasurement: (step: CyclingStaticStep) => void;
+  /** Cancel current measurement */
+  cancelMeasurement: () => void;
+  /** Recorded measurements */
+  measurements: {
+    heelOnPedal: CyclingStaticMeasurement | null;
+    clippedIn: CyclingStaticMeasurement | null;
+  };
+  /** Final result (available after both measurements) */
+  result: CyclingStaticResult | null;
+  /** Reset all analysis data */
+  reset: () => void;
+  /** Set custom countdown duration */
+  setCountdownDuration: (seconds: number) => void;
+  /** Current countdown duration setting */
+  countdownDuration: number;
+}
+
+/**
+ * Generate analysis from measurements
+ */
+function generateAnalysis(
+  heelMeasurement: CyclingStaticMeasurement | null,
+  clippedMeasurement: CyclingStaticMeasurement | null,
+  thresholds: CyclingStaticThresholds
+): CyclingStaticAnalysis {
+  const heelKnee = heelMeasurement?.kneeAngle ?? null;
+  const clippedKnee = clippedMeasurement?.kneeAngle ?? null;
+  const angleDiff = heelKnee !== null && clippedKnee !== null
+    ? heelKnee - clippedKnee
+    : null;
+
+  // Saddle assessment
+  let saddleStatus: 'optimal' | 'too_low' | 'too_high' | 'unknown' = 'unknown';
+  let saddleAssessmentText = '';
+  const saddleRecommendations: string[] = [];
+
+  if (heelKnee !== null && clippedKnee !== null) {
+    // Check heel-on-pedal measurement (should be nearly straight ~170-180°)
+    const heelOk = heelKnee >= thresholds.heelKneeAngleIdealMin;
+
+    // Check clipped-in measurement (should be 145-155°)
+    const clippedTooLow = clippedKnee < thresholds.clippedKneeAngleIdealMin;
+    const clippedTooHigh = clippedKnee > thresholds.clippedKneeAngleIdealMax;
+    const clippedOk = !clippedTooLow && !clippedTooHigh;
+
+    if (heelOk && clippedOk) {
+      saddleStatus = 'optimal';
+      saddleAssessmentText = `Eccellente! Con il tallone sul pedale la gamba e quasi completamente estesa (${Math.round(heelKnee)}°) e con il pedale agganciato l'angolo del ginocchio (${Math.round(clippedKnee)}°) e nell'intervallo ideale (${thresholds.clippedKneeAngleIdealMin}°-${thresholds.clippedKneeAngleIdealMax}°).`;
+    } else if (clippedTooLow) {
+      saddleStatus = 'too_low';
+      saddleAssessmentText = `Sella troppo bassa. L'angolo del ginocchio con il pedale agganciato (${Math.round(clippedKnee)}°) e inferiore al minimo consigliato di ${thresholds.clippedKneeAngleIdealMin}°. Questo puo aumentare lo stress sul ginocchio.`;
+      saddleRecommendations.push('Alza la sella di 5-10mm alla volta');
+      saddleRecommendations.push('Dopo ogni regolazione, rifai il test per verificare');
+      saddleRecommendations.push('Un angolo troppo chiuso aumenta lo stress sulle ginocchia');
+    } else if (clippedTooHigh) {
+      saddleStatus = 'too_high';
+      saddleAssessmentText = `Sella troppo alta. L'angolo del ginocchio con il pedale agganciato (${Math.round(clippedKnee)}°) e superiore al massimo consigliato di ${thresholds.clippedKneeAngleIdealMax}°. Questo puo causare oscillazione del bacino e problemi alla parte posteriore del ginocchio.`;
+      saddleRecommendations.push('Abbassa la sella di 5-10mm alla volta');
+      saddleRecommendations.push('Una sella troppo alta causa oscillazione del bacino');
+      saddleRecommendations.push('Puo anche causare dolore dietro al ginocchio');
+    } else if (!heelOk) {
+      saddleStatus = 'too_low';
+      saddleAssessmentText = `Con il tallone sul pedale, la gamba non raggiunge l'estensione completa (${Math.round(heelKnee)}°). Questo indica che la sella potrebbe essere troppo bassa.`;
+      saddleRecommendations.push('Alza la sella finche la gamba non e quasi dritta con il tallone sul pedale');
+    }
+  } else if (heelKnee !== null) {
+    if (heelKnee >= thresholds.heelKneeAngleIdealMin) {
+      saddleAssessmentText = `Con il tallone sul pedale: buona estensione (${Math.round(heelKnee)}°). Completa la misurazione con il pedale agganciato.`;
+    } else {
+      saddleAssessmentText = `Con il tallone sul pedale: estensione insufficiente (${Math.round(heelKnee)}°). La sella potrebbe essere troppo bassa.`;
+    }
+  } else if (clippedKnee !== null) {
+    if (clippedKnee >= thresholds.clippedKneeAngleIdealMin && clippedKnee <= thresholds.clippedKneeAngleIdealMax) {
+      saddleAssessmentText = `Con il pedale agganciato: angolo buono (${Math.round(clippedKnee)}°). Completa la misurazione con il tallone.`;
+    } else {
+      saddleAssessmentText = `Con il pedale agganciato: angolo ${clippedKnee < thresholds.clippedKneeAngleIdealMin ? 'troppo chiuso' : 'troppo aperto'} (${Math.round(clippedKnee)}°).`;
+    }
+  } else {
+    saddleAssessmentText = 'Misurazioni non disponibili. Completa entrambi i test.';
+  }
+
+  // Leg extension analysis
+  let heelExtension = 'Non misurato';
+  let clippedExtension = 'Non misurato';
+  let extensionAssessment = '';
+
+  if (heelKnee !== null) {
+    if (heelKnee >= 175) {
+      heelExtension = `Estensione completa (${Math.round(heelKnee)}°)`;
+    } else if (heelKnee >= thresholds.heelKneeAngleIdealMin) {
+      heelExtension = `Buona estensione (${Math.round(heelKnee)}°)`;
+    } else {
+      heelExtension = `Estensione limitata (${Math.round(heelKnee)}°)`;
+    }
+  }
+
+  if (clippedKnee !== null) {
+    if (clippedKnee >= thresholds.clippedKneeAngleIdealMin && clippedKnee <= thresholds.clippedKneeAngleIdealMax) {
+      clippedExtension = `Flessione ottimale (${Math.round(clippedKnee)}°)`;
+    } else if (clippedKnee < thresholds.clippedKneeAngleIdealMin) {
+      clippedExtension = `Troppo flesso (${Math.round(clippedKnee)}°)`;
+    } else {
+      clippedExtension = `Troppo esteso (${Math.round(clippedKnee)}°)`;
+    }
+  }
+
+  if (angleDiff !== null) {
+    extensionAssessment = `Differenza tra le due posizioni: ${Math.round(angleDiff)}°. `;
+    if (angleDiff >= 20 && angleDiff <= 35) {
+      extensionAssessment += 'La differenza e nella norma.';
+    } else if (angleDiff < 20) {
+      extensionAssessment += 'Differenza inferiore alla norma - verifica la posizione del piede.';
+    } else {
+      extensionAssessment += 'Differenza elevata - potresti avere bisogno di alzare il tallone durante la pedalata.';
+    }
+  }
+
+  // Position assessment
+  const hipAngle = clippedMeasurement?.hipAngle ?? heelMeasurement?.hipAngle ?? null;
+  const trunkAngle = clippedMeasurement?.trunkAngle ?? heelMeasurement?.trunkAngle ?? null;
+  let positionAssessment = '';
+  const positionRecommendations: string[] = [];
+
+  if (hipAngle !== null) {
+    if (hipAngle < 80) {
+      positionAssessment = `Posizione molto aggressiva (angolo anca ${Math.round(hipAngle)}°). `;
+      positionRecommendations.push('Questa posizione richiede buona flessibilita');
+    } else if (hipAngle > 120) {
+      positionAssessment = `Posizione molto eretta (angolo anca ${Math.round(hipAngle)}°). `;
+    } else {
+      positionAssessment = `Angolo dell anca nella norma (${Math.round(hipAngle)}°). `;
+    }
+  }
+
+  if (trunkAngle !== null) {
+    if (trunkAngle < 30) {
+      positionAssessment += `Tronco molto inclinato in avanti (${Math.round(trunkAngle)}° dalla verticale).`;
+    } else if (trunkAngle > 60) {
+      positionAssessment += `Posizione del tronco eretta (${Math.round(trunkAngle)}° dalla verticale).`;
+    } else {
+      positionAssessment += `Inclinazione del tronco bilanciata (${Math.round(trunkAngle)}° dalla verticale).`;
+    }
+  }
+
+  // Overall recommendations
+  const overallRecommendations: string[] = [];
+  if (saddleRecommendations.length > 0) {
+    overallRecommendations.push(...saddleRecommendations.slice(0, 2));
+  }
+  if (positionRecommendations.length > 0) {
+    overallRecommendations.push(...positionRecommendations);
+  }
+  if (saddleStatus === 'optimal') {
+    overallRecommendations.push('L\'altezza della sella e ottimale - mantieni questa posizione');
+  }
+
+  // Calculate bike fit score
+  let bikeFitScore = 50; // Base score
+
+  if (saddleStatus === 'optimal') {
+    bikeFitScore += 40;
+  } else if (saddleStatus !== 'unknown') {
+    bikeFitScore += 15;
+  }
+
+  if (heelKnee !== null && heelKnee >= thresholds.heelKneeAngleIdealMin) {
+    bikeFitScore += 10;
+  }
+
+  bikeFitScore = Math.min(100, Math.max(0, bikeFitScore));
+
+  return {
+    saddleAssessment: {
+      status: saddleStatus,
+      heelKneeAngle: heelKnee,
+      clippedKneeAngle: clippedKnee,
+      angleDifference: angleDiff,
+      assessment: saddleAssessmentText,
+      recommendations: saddleRecommendations,
+    },
+    legExtensionAnalysis: {
+      heelExtension,
+      clippedExtension,
+      assessment: extensionAssessment,
+    },
+    positionAssessment: {
+      hipAngle,
+      trunkAngle,
+      assessment: positionAssessment || 'Posizione non valutata',
+      recommendations: positionRecommendations,
+    },
+    overallRecommendations,
+    bikeFitScore,
+  };
+}
+
+/**
+ * Custom hook for static cycling saddle height analysis
+ */
+export function useCyclingStaticAnalysis(
+  config: Partial<CyclingStaticConfig> = {}
+): UseCyclingStaticAnalysisReturn {
+  const finalConfig = { ...DEFAULT_CONFIG, ...config };
+
+  // State
+  const [currentAngles, setCurrentAngles] = useState<CyclingStaticAngles>({
+    kneeAngle: null,
+    hipAngle: null,
+    ankleAngle: null,
+    trunkAngle: null,
+    confidence: 0,
+  });
+
+  const [status, setStatus] = useState<CyclingStaticStatus>('idle');
+  const [isInReadyPosition, setIsInReadyPosition] = useState(false);
+  const [countdownRemaining, setCountdownRemaining] = useState(0);
+  const [countdownDuration, setCountdownDuration] = useState(finalConfig.countdownSeconds);
+
+  const [measurements, setMeasurements] = useState<{
+    heelOnPedal: CyclingStaticMeasurement | null;
+    clippedIn: CyclingStaticMeasurement | null;
+  }>({
+    heelOnPedal: null,
+    clippedIn: null,
+  });
+
+  const [result, setResult] = useState<CyclingStaticResult | null>(null);
+
+  // Refs
+  const currentStepRef = useRef<CyclingStaticStep | null>(null);
+  const measurementBufferRef = useRef<CyclingStaticAngles[]>([]);
+  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const readyPositionCountRef = useRef<number>(0);
+
+  /**
+   * Compute angles from a pose frame
+   */
+  const computeAngles = useCallback((frame: PoseFrame): CyclingStaticAngles => {
+    const kp = frame.keypoints;
+
+    // Get keypoints with confidence
+    const leftShoulder = getKeypointByName(kp, 'left_shoulder');
+    const rightShoulder = getKeypointByName(kp, 'right_shoulder');
+    const leftHip = getKeypointByName(kp, 'left_hip');
+    const rightHip = getKeypointByName(kp, 'right_hip');
+    const leftKnee = getKeypointByName(kp, 'left_knee');
+    const rightKnee = getKeypointByName(kp, 'right_knee');
+    const leftAnkle = getKeypointByName(kp, 'left_ankle');
+    const rightAnkle = getKeypointByName(kp, 'right_ankle');
+    const leftFoot = getKeypointByName(kp, 'left_foot_index');
+    const rightFoot = getKeypointByName(kp, 'right_foot_index');
+
+    // Convert to points
+    const leftShoulderPt = keypointToPoint(leftShoulder);
+    const rightShoulderPt = keypointToPoint(rightShoulder);
+    const leftHipPt = keypointToPoint(leftHip);
+    const rightHipPt = keypointToPoint(rightHip);
+    const leftKneePt = keypointToPoint(leftKnee);
+    const rightKneePt = keypointToPoint(rightKnee);
+    const leftAnklePt = keypointToPoint(leftAnkle);
+    const rightAnklePt = keypointToPoint(rightAnkle);
+    const leftFootPt = keypointToPoint(leftFoot);
+    const rightFootPt = keypointToPoint(rightFoot);
+
+    // For side view, use whichever leg is more visible (higher confidence)
+    // The user should be positioned with one side to the camera
+    const leftLegConfidence = Math.min(
+      leftHip?.score ?? 0,
+      leftKnee?.score ?? 0,
+      leftAnkle?.score ?? 0
+    );
+    const rightLegConfidence = Math.min(
+      rightHip?.score ?? 0,
+      rightKnee?.score ?? 0,
+      rightAnkle?.score ?? 0
+    );
+
+    let kneeAngle: number | null = null;
+    let hipAngle: number | null = null;
+    let ankleAngle: number | null = null;
+    let overallConfidence = 0;
+
+    if (leftLegConfidence > rightLegConfidence && leftLegConfidence >= finalConfig.thresholds.confidenceThreshold) {
+      // Use left leg
+      kneeAngle = angleBetweenPoints(leftHipPt, leftKneePt, leftAnklePt);
+      hipAngle = angleBetweenPoints(leftShoulderPt, leftHipPt, leftKneePt);
+      ankleAngle = angleBetweenPoints(leftKneePt, leftAnklePt, leftFootPt);
+      overallConfidence = leftLegConfidence;
+    } else if (rightLegConfidence >= finalConfig.thresholds.confidenceThreshold) {
+      // Use right leg
+      kneeAngle = angleBetweenPoints(rightHipPt, rightKneePt, rightAnklePt);
+      hipAngle = angleBetweenPoints(rightShoulderPt, rightHipPt, rightKneePt);
+      ankleAngle = angleBetweenPoints(rightKneePt, rightAnklePt, rightFootPt);
+      overallConfidence = rightLegConfidence;
+    }
+
+    // Compute trunk angle
+    const shoulderMid =
+      leftShoulderPt && rightShoulderPt
+        ? { x: (leftShoulderPt.x + rightShoulderPt.x) / 2, y: (leftShoulderPt.y + rightShoulderPt.y) / 2 }
+        : leftShoulderPt || rightShoulderPt;
+    const hipMid =
+      leftHipPt && rightHipPt
+        ? { x: (leftHipPt.x + rightHipPt.x) / 2, y: (leftHipPt.y + rightHipPt.y) / 2 }
+        : leftHipPt || rightHipPt;
+    const trunkAngle = angleFromVertical(shoulderMid, hipMid);
+
+    return {
+      kneeAngle,
+      hipAngle,
+      ankleAngle,
+      trunkAngle,
+      confidence: overallConfidence,
+    };
+  }, [finalConfig.thresholds.confidenceThreshold]);
+
+  /**
+   * Check if user is in ready position (seated on bike at 6 o'clock)
+   */
+  const checkReadyPosition = useCallback((angles: CyclingStaticAngles): boolean => {
+    if (angles.kneeAngle === null || angles.confidence < finalConfig.thresholds.confidenceThreshold) {
+      return false;
+    }
+
+    // User is in ready position when knee angle exceeds threshold (leg more extended = at 6 o'clock)
+    // This indicates the leg is down in the pedaling position
+    return angles.kneeAngle > finalConfig.thresholds.readyPositionKneeAngle;
+  }, [finalConfig.thresholds]);
+
+  /**
+   * Complete measurement with averaged values
+   */
+  const completeMeasurement = useCallback(() => {
+    const buffer = measurementBufferRef.current;
+    if (buffer.length === 0 || !currentStepRef.current) return;
+
+    // Average all measurements
+    const validMeasurements = buffer.filter(m => m.kneeAngle !== null);
+    if (validMeasurements.length === 0) return;
+
+    const avgKnee = validMeasurements.reduce((sum, m) => sum + (m.kneeAngle || 0), 0) / validMeasurements.length;
+    const avgHip = validMeasurements
+      .filter(m => m.hipAngle !== null)
+      .reduce((sum, m, _, arr) => sum + (m.hipAngle || 0) / arr.length, 0) || null;
+    const avgAnkle = validMeasurements
+      .filter(m => m.ankleAngle !== null)
+      .reduce((sum, m, _, arr) => sum + (m.ankleAngle || 0) / arr.length, 0) || null;
+    const avgTrunk = validMeasurements
+      .filter(m => m.trunkAngle !== null)
+      .reduce((sum, m, _, arr) => sum + (m.trunkAngle || 0) / arr.length, 0) || null;
+    const avgConfidence = validMeasurements.reduce((sum, m) => sum + m.confidence, 0) / validMeasurements.length;
+
+    const measurement: CyclingStaticMeasurement = {
+      step: currentStepRef.current,
+      kneeAngle: avgKnee,
+      hipAngle: avgHip,
+      ankleAngle: avgAnkle,
+      trunkAngle: avgTrunk,
+      timestamp: Date.now(),
+      confidence: avgConfidence,
+    };
+
+    // Update measurements
+    setMeasurements(prev => {
+      const updated = currentStepRef.current === 'heel_on_pedal'
+        ? { ...prev, heelOnPedal: measurement }
+        : { ...prev, clippedIn: measurement };
+
+      // Generate analysis and result
+      const analysis = generateAnalysis(
+        updated.heelOnPedal,
+        updated.clippedIn,
+        finalConfig.thresholds
+      );
+
+      // Create result if we have at least one measurement
+      const newResult: CyclingStaticResult = {
+        heelOnPedal: updated.heelOnPedal,
+        clippedIn: updated.clippedIn,
+        analysis,
+        completedAt: Date.now(),
+      };
+      setResult(newResult);
+
+      return updated;
+    });
+
+    // Clear state
+    currentStepRef.current = null;
+    measurementBufferRef.current = [];
+    setStatus('completed');
+  }, [finalConfig.thresholds]);
+
+  /**
+   * Process a new pose frame
+   */
+  const processFrame = useCallback((frame: PoseFrame) => {
+    if (!frame.isValid) return;
+
+    // Compute current angles
+    const angles = computeAngles(frame);
+    setCurrentAngles(angles);
+
+    // Check ready position
+    const ready = checkReadyPosition(angles);
+
+    // Need consistent ready position (multiple consecutive frames)
+    if (ready) {
+      readyPositionCountRef.current++;
+    } else {
+      readyPositionCountRef.current = 0;
+    }
+
+    setIsInReadyPosition(readyPositionCountRef.current >= 5);
+
+    // If measuring, add to buffer
+    if (status === 'measuring' && currentStepRef.current) {
+      measurementBufferRef.current.push(angles);
+
+      // Check if we have enough measurements
+      if (measurementBufferRef.current.length >= finalConfig.measurementFrames) {
+        completeMeasurement();
+      }
+    }
+  }, [computeAngles, checkReadyPosition, status, finalConfig.measurementFrames, completeMeasurement]);
+
+  /**
+   * Start measurement for a step
+   */
+  const startMeasurement = useCallback((step: CyclingStaticStep) => {
+    currentStepRef.current = step;
+    measurementBufferRef.current = [];
+    setCountdownRemaining(countdownDuration);
+    setStatus('countdown');
+
+    // Start countdown
+    countdownIntervalRef.current = setInterval(() => {
+      setCountdownRemaining(prev => {
+        if (prev <= 1) {
+          // Countdown finished, start measuring
+          if (countdownIntervalRef.current) {
+            clearInterval(countdownIntervalRef.current);
+            countdownIntervalRef.current = null;
+          }
+          setStatus('measuring');
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, [countdownDuration]);
+
+  /**
+   * Cancel current measurement
+   */
+  const cancelMeasurement = useCallback(() => {
+    if (countdownIntervalRef.current) {
+      clearInterval(countdownIntervalRef.current);
+      countdownIntervalRef.current = null;
+    }
+    currentStepRef.current = null;
+    measurementBufferRef.current = [];
+    setCountdownRemaining(0);
+    setStatus('idle');
+  }, []);
+
+  /**
+   * Reset all analysis data
+   */
+  const reset = useCallback(() => {
+    cancelMeasurement();
+    setCurrentAngles({
+      kneeAngle: null,
+      hipAngle: null,
+      ankleAngle: null,
+      trunkAngle: null,
+      confidence: 0,
+    });
+    setIsInReadyPosition(false);
+    setMeasurements({
+      heelOnPedal: null,
+      clippedIn: null,
+    });
+    setResult(null);
+    readyPositionCountRef.current = 0;
+  }, [cancelMeasurement]);
+
+  /**
+   * Set custom countdown duration
+   */
+  const setCountdownDurationFn = useCallback((seconds: number) => {
+    setCountdownDuration(Math.max(1, Math.min(30, seconds)));
+  }, []);
+
+  return {
+    processFrame,
+    currentAngles,
+    status,
+    isInReadyPosition,
+    countdownRemaining,
+    startMeasurement,
+    cancelMeasurement,
+    measurements,
+    result,
+    reset,
+    setCountdownDuration: setCountdownDurationFn,
+    countdownDuration,
+  };
+}
+
+export default useCyclingStaticAnalysis;

--- a/src/lib/poseTypes.ts
+++ b/src/lib/poseTypes.ts
@@ -767,3 +767,125 @@ export interface CyclingSessionSummary {
   /** Overall assessment text */
   overallAssessment: string;
 }
+
+// ============================================================================
+// CYCLING STATIC MODE TYPES
+// ============================================================================
+
+/**
+ * Cycling mode type - static or dynamic
+ */
+export type CyclingMode = 'static' | 'dynamic';
+
+/**
+ * Step type for static cycling analysis
+ */
+export type CyclingStaticStep = 'heel_on_pedal' | 'clipped_in';
+
+/**
+ * Configuration for cycling static steps
+ */
+export interface CyclingStaticStepConfig {
+  /** Step identifier */
+  step: CyclingStaticStep;
+  /** Display label */
+  label: string;
+  /** Instruction for the user */
+  instruction: string;
+  /** Icon identifier */
+  icon: string;
+}
+
+/**
+ * Recorded measurement for a static step
+ */
+export interface CyclingStaticMeasurement {
+  /** Step type */
+  step: CyclingStaticStep;
+  /** Knee angle measured */
+  kneeAngle: number;
+  /** Hip angle measured */
+  hipAngle: number | null;
+  /** Ankle angle measured */
+  ankleAngle: number | null;
+  /** Trunk angle measured */
+  trunkAngle: number | null;
+  /** Timestamp of measurement */
+  timestamp: number;
+  /** Confidence score of measurement */
+  confidence: number;
+}
+
+/**
+ * Result of static cycling analysis
+ */
+export interface CyclingStaticResult {
+  /** Heel on pedal measurement */
+  heelOnPedal: CyclingStaticMeasurement | null;
+  /** Clipped in measurement */
+  clippedIn: CyclingStaticMeasurement | null;
+  /** Analysis summary */
+  analysis: CyclingStaticAnalysis;
+  /** Completion timestamp */
+  completedAt: number;
+}
+
+/**
+ * Static cycling analysis breakdown
+ */
+export interface CyclingStaticAnalysis {
+  /** Saddle height assessment */
+  saddleAssessment: {
+    status: 'optimal' | 'too_low' | 'too_high' | 'unknown';
+    heelKneeAngle: number | null;
+    clippedKneeAngle: number | null;
+    angleDifference: number | null;
+    assessment: string;
+    recommendations: string[];
+  };
+  /** Leg extension analysis */
+  legExtensionAnalysis: {
+    heelExtension: string;
+    clippedExtension: string;
+    assessment: string;
+  };
+  /** Position assessment */
+  positionAssessment: {
+    hipAngle: number | null;
+    trunkAngle: number | null;
+    assessment: string;
+    recommendations: string[];
+  };
+  /** Overall recommendations */
+  overallRecommendations: string[];
+  /** Bike fit score (0-100) */
+  bikeFitScore: number;
+}
+
+/**
+ * Thresholds for static cycling analysis
+ */
+export interface CyclingStaticThresholds {
+  /** Ideal knee angle range with heel on pedal (should be ~180° = full extension) */
+  heelKneeAngleIdealMin: number;
+  heelKneeAngleIdealMax: number;
+  /** Ideal knee angle range when clipped in (should be 145-155°) */
+  clippedKneeAngleIdealMin: number;
+  clippedKneeAngleIdealMax: number;
+  /** Minimum knee angle to detect "ready position" (seated on bike) */
+  readyPositionKneeAngle: number;
+  /** Confidence threshold for valid measurement */
+  confidenceThreshold: number;
+}
+
+/**
+ * Default thresholds for static cycling analysis
+ */
+export const DEFAULT_CYCLING_STATIC_THRESHOLDS: CyclingStaticThresholds = {
+  heelKneeAngleIdealMin: 170,    // Nearly straight leg with heel
+  heelKneeAngleIdealMax: 180,    // Full extension
+  clippedKneeAngleIdealMin: 145, // Slight bend when clipped
+  clippedKneeAngleIdealMax: 155, // Not too bent
+  readyPositionKneeAngle: 120,   // Knee bent enough = seated on bike
+  confidenceThreshold: 0.6,
+};


### PR DESCRIPTION
- Add CyclingModeSelector component for choosing between Static/Dynamic modes
- Create CyclingStaticCaptureView component with:
  - Side camera view for lateral analysis
  - 2-step measurement workflow (heel on pedal, clipped in)
  - Configurable countdown before measurement
  - Auto-detection of ready position (knee angle > 120°)
  - Real-time angle display and results view
- Add useCyclingStaticAnalysis hook with:
  - Knee angle measurement at 6 o'clock position
  - Analysis generation based on measurements
  - Saddle height recommendations
- Add cycling static types to poseTypes.ts
- Update App.tsx routes: /cycling -> mode selector, /cycling/static, /cycling/dynamic